### PR TITLE
necessary changes for GNOME45 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,9 @@
-const { Gio, GObject} = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const extension = ExtensionUtils.getCurrentExtension();
-const Main = imports.ui.main;
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+
+import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 let signal_overlay_key = null;
 let original_signal_overlay_key = null;
@@ -37,45 +39,49 @@ function overlay_key_changed(settings) {
 
 function init(metadata) {}
 
-function enable() {
+export default class MyTestExtension extends Extension {
 
-    settings = ExtensionUtils.getSettings((extension.metadata["settings-schema"]));
+	enable() {
+	
+	    settings = this.getSettings();
+	
+	    // Load overlay key action and keep it up to date with settings
+	    overlay_key_changed(settings);
+	    settings.connect("changed::overlay-key-action", () => {
+	        overlay_key_changed(settings);
+	    });
+	
+	    // Block original overlay key handler
+	    original_signal_overlay_key = GObject.signal_handler_find(global.display, { signalId: "overlay-key" });
+	    if (original_signal_overlay_key !== null) {
+	        global.display.block_signal_handler(original_signal_overlay_key);
+	    }
+	
+	    // Connect modified overlay key handler
+	    const A11Y_SCHEMA = 'org.gnome.desktop.a11y.keyboard';
+	    const STICKY_KEYS_ENABLE = 'stickykeys-enable';
+	    let _a11ySettings = new Gio.Settings({ schema_id: A11Y_SCHEMA });
+	    signal_overlay_key = global.display.connect("overlay-key", () => {
+	        if (!_a11ySettings.get_boolean(STICKY_KEYS_ENABLE))
+	            overlay_key();
+	    });
+	}
 
-    // Load overlay key action and keep it up to date with settings
-    overlay_key_changed(settings);
-    settings.connect("changed::overlay-key-action", () => {
-        overlay_key_changed(settings);
-    });
-
-    // Block original overlay key handler
-    original_signal_overlay_key = GObject.signal_handler_find(global.display, { signalId: "overlay-key" });
-    if (original_signal_overlay_key !== null) {
-        global.display.block_signal_handler(original_signal_overlay_key);
-    }
-
-    // Connect modified overlay key handler
-    const A11Y_SCHEMA = 'org.gnome.desktop.a11y.keyboard';
-    const STICKY_KEYS_ENABLE = 'stickykeys-enable';
-    let _a11ySettings = new Gio.Settings({ schema_id: A11Y_SCHEMA });
-    signal_overlay_key = global.display.connect("overlay-key", () => {
-        if (!_a11ySettings.get_boolean(STICKY_KEYS_ENABLE))
-            overlay_key();
-    });
-}
-
-function disable() {
-
-    // Disconnect modified overlay key handler
-    if (signal_overlay_key !== null) {
-        global.display.disconnect(signal_overlay_key);
-        signal_overlay_key = null;
-    }
-
-    // Unblock original overlay key handler
-    if (original_signal_overlay_key !== null) {
-        global.display.unblock_signal_handler(original_signal_overlay_key);
-        original_signal_overlay_key = null;
-    }
-
-    settings =  null;
+	disable() {
+	
+	    // Disconnect modified overlay key handler
+	    if (signal_overlay_key !== null) {
+	        global.display.disconnect(signal_overlay_key);
+	        signal_overlay_key = null;
+	    }
+	
+	    // Unblock original overlay key handler
+	    if (original_signal_overlay_key !== null) {
+	        global.display.unblock_signal_handler(original_signal_overlay_key);
+	        original_signal_overlay_key = null;
+	    }
+	
+	    settings =  null;
+	}
+	
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,11 +3,9 @@
   "name": "Super Key",
   "settings-schema": "org.gnome.shell.extensions.super-key",
   "shell-version": [
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/tommimon",
   "uuid": "super-key@tommimon.github.com",
-  "version": 4
+  "version": 5
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,42 +1,46 @@
+import Adw from 'gi://Adw';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
 
-
-const { Adw, Gio, Gtk } = imports.gi;
-
-const ExtensionUtils = imports.misc.extensionUtils;
+import * as ExtensionUtils from 'resource:///org/gnome/Shell/Extensions/js/misc/extensionUtils.js';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 function init() {
 
 }
 
-function fillPreferencesWindow(window) {
-    // Use the same GSettings schema as in `extension.js`
-    const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.super-key');
-
-    // Create a preferences page and group
-    const page = new Adw.PreferencesPage();
-    const group = new Adw.PreferencesGroup();
-    page.add(group);
-
-    // Create a new preferences row
-    const row = new Adw.ActionRow({ title: 'Super key command' });
-    group.add(row);
-
-    // Create the switch and bind its value to the `overlay-key-action` key
-    const textField = new Gtk.Entry({
-        text: settings.get_string ('overlay-key-action'),
-        valign: Gtk.Align.CENTER,
-    });
-
-    settings.bind(
-        'overlay-key-action',
-        textField,
-        'text',
-        Gio.SettingsBindFlags.DEFAULT
-    );
-
-    // Add the switch to the row
-    row.add_suffix(textField);
-
-    // Add our page to the window
-    window.add(page);
+export default class MyExtensionPreferences extends ExtensionPreferences {
+	fillPreferencesWindow(window) {
+	    // Use the same GSettings schema as in `extension.js`
+	    const settings = this.getSettings();
+	
+	    // Create a preferences page and group
+	    const page = new Adw.PreferencesPage();
+	    const group = new Adw.PreferencesGroup();
+	    page.add(group);
+	
+	    // Create a new preferences row
+	    const row = new Adw.ActionRow({ title: 'Super key command' });
+	    group.add(row);
+	
+	    // Create the switch and bind its value to the `overlay-key-action` key
+	    const textField = new Gtk.Entry({
+	        text: settings.get_string ('overlay-key-action'),
+	        valign: Gtk.Align.CENTER,
+	    });
+	
+	    settings.bind(
+	        'overlay-key-action',
+	        textField,
+	        'text',
+	        Gio.SettingsBindFlags.DEFAULT
+	    );
+	
+	    // Add the switch to the row
+	    row.add_suffix(textField);
+	
+	    // Add our page to the window
+	    window.add(page);
+	}
+	
 }


### PR DESCRIPTION
Followed guide here:
https://gjs.guide/extensions/upgrading/gnome-shell-45.html#extension-js

Some structural changes dealing with export class, library calls, and getSettings call.

My only coding experience is with math / machine learning algorithms, no javascript experience. However, these changes were simple enough to do. You may need to adjust some things if I'm not following standard JS notation.

Works on my Fedora 39 system with ulauncher.